### PR TITLE
Update BigDecimal.new to BigDecimal()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## v2.0.0
+- Adding `bigdecimal ~> 2.0.0` as a gem dependency and updating BigDecimal constructors
+
 ## v1.5.3
 
 - [#266](https://github.com/chingor13/json_api_client/pull/266) - Fix default attributes being overridden

--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "faraday_middleware", '~> 0.9'
   s.add_dependency "addressable", '~> 2.2'
   s.add_dependency "activemodel", '>= 3.2.0'
+  s.add_dependency "bigdecimal", "~> 2.0.0"
 
   s.add_development_dependency "webmock"
   s.add_development_dependency "mocha"

--- a/lib/json_api_client/schema.rb
+++ b/lib/json_api_client/schema.rb
@@ -29,7 +29,7 @@ module JsonApiClient
 
       class Decimal
         def self.cast(value, _)
-          BigDecimal.new(value)
+          BigDecimal(value)
         end
       end
 

--- a/lib/json_api_client/version.rb
+++ b/lib/json_api_client/version.rb
@@ -1,3 +1,3 @@
 module JsonApiClient
-  VERSION = "1.5.3"
+  VERSION = "2.0.0"
 end

--- a/test/unit/coercion_test.rb
+++ b/test/unit/coercion_test.rb
@@ -88,6 +88,6 @@ class CoercionTest < MiniTest::Test
     assert_equal target.integer_me, 2
     assert_equal target.string_me, '1.0'
     assert_equal target.time_me, Time.parse(TIME_STRING)
-    assert_equal target.decimal_me, BigDecimal.new('1.5')
+    assert_equal target.decimal_me, BigDecimal('1.5')
   end
 end


### PR DESCRIPTION
There was already an instance where we used `BigDecimal()` constructor notation but there were 2 leftover instances that still used `BigDecimal.new`, so I'm just updating the others so we can continue to use this gem as we update consuming projects to `bigdecimal >= 2.0`