### PR TITLE
bigdecimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## v2.0.1
+- relax bigdecimal version constraints
+
 ## v2.0.0
 - Adding `bigdecimal ~> 2.0.0` as a gem dependency and updating BigDecimal constructors
 

--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "faraday_middleware", '~> 0.9'
   s.add_dependency "addressable", '~> 2.2'
   s.add_dependency "activemodel", '>= 3.2.0'
-  s.add_dependency "bigdecimal", "~> 2.0.0"
+  s.add_dependency "bigdecimal"
 
   s.add_development_dependency "webmock"
   s.add_development_dependency "mocha"

--- a/lib/json_api_client/version.rb
+++ b/lib/json_api_client/version.rb
@@ -1,3 +1,3 @@
 module JsonApiClient
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
since this gem supports both bigdecimal 1 and 2, can we relax the constraints here to make life easier downstream?  I'm running into an issue updating gems in server-api because of this change and https://github.com/1debit/chime-atlas/blob/master/chime-atlas.gemspec#L33