### PR TITLE
handle 429 errors

### DIFF
--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -28,8 +28,12 @@ module JsonApiClient
           raise Errors::NotFound, env[:url]
         when 409
           raise Errors::Conflict, env
+        when 429
+          raise Errors::ApiError, env
         when 400..499
           # some other error
+          # TODO: raise Errors::ApiError, env
+          # https://github.com/JsonApiClient/json_api_client/blame/master/lib/json_api_client/middleware/status.rb#L46
         when 500..599
           raise Errors::ServerError, env
         else

--- a/lib/json_api_client/version.rb
+++ b/lib/json_api_client/version.rb
@@ -1,3 +1,3 @@
 module JsonApiClient
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end

--- a/test/unit/status_test.rb
+++ b/test/unit/status_test.rb
@@ -56,4 +56,18 @@ class StatusTest < MiniTest::Test
     end
   end
 
+  # https://github.com/JsonApiClient/json_api_client/blame/master/test/unit/status_test.rb#L59
+  # def test_server_responding_with_408_status
+  #   stub_request(:get, "http://example.com/users/1")
+  #     .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+  #       meta: {
+  #         status: 408,
+  #         message: "Request timeout"
+  #       }
+  #     }.to_json)
+
+  #   assert_raises JsonApiClient::Errors::ClientError do
+  #     User.find(1)
+  #   end
+  # end
 end


### PR DESCRIPTION
400-499 errors codes should raise an exception, not fail silently.  this has already been patched upstread:

https://github.com/JsonApiClient/json_api_client/blame/master/lib/json_api_client/middleware/status.rb#L46

cross testing: https://github.com/1debit/server-api/pull/2602